### PR TITLE
Ensure safe packet sizes

### DIFF
--- a/src/conn.rs
+++ b/src/conn.rs
@@ -1,7 +1,7 @@
 use std::net::{TcpStream, ToSocketAddrs};
 
 use crate::error::RconError;
-use crate::packet::{Packet, PacketType};
+use crate::packet::{MsgType, Packet, RconReq, RconResp};
 
 pub struct Connection {
     stream: TcpStream,
@@ -20,12 +20,12 @@ impl Connection {
         // Note: A server responds with an empty `ResponseValue` followed by an `AuthResponse`.
         // The server uses the `AuthResponse` packet ID as status code, so the response ID should
         // be paired with the `ResponseValue` packet.
-        self.send(PacketType::Auth, password)?;
+        self.send(RconReq::Auth, password)?;
 
         // Receive `AuthResponse`.
         let auth_response = loop {
             let r = Packet::deserialize(&mut self.stream)?;
-            if r.ptype == PacketType::AuthResponse {
+            if r.ptype == MsgType::Response(RconResp::AuthResponse) {
                 break r;
             }
         };
@@ -41,14 +41,14 @@ impl Connection {
     pub fn exec(&mut self, cmd: &str) -> Result<String, RconError> {
         // Note: A server responds with one or more `ResponseValue`.
         // The max packet size is 4096 (default), but may differ between game servers.
-        self.send(PacketType::ExecCommand, cmd)?;
+        self.send(RconReq::ExecCommand, cmd)?;
         let response = self.recv_multi_packet_response()?;
         Ok(response)
     }
 
-    fn send(&mut self, ptype: PacketType, body: &str) -> Result<i32, RconError> {
+    fn send(&mut self, request: RconReq, body: &str) -> Result<i32, RconError> {
         let id = self.fetch_and_add_id();
-        let packet = Packet::new(id, ptype, body.into());
+        let packet = Packet::new(id, MsgType::Request(request), body.into());
         packet.serialize(&mut self.stream)?;
         Ok(id)
     }
@@ -58,7 +58,7 @@ impl Connection {
         // Since the server always responds to requests in the receiving order (FIFO), we
         // can detect the end of a multi-packet response when receiving the response to the
         // empty packet.
-        let end_id = self.send(PacketType::ExecCommand, "")?; // empty packet
+        let end_id = self.send(RconReq::ExecCommand, "")?; // empty packet
         let mut response = String::new();
         loop {
             let recv_packet = Packet::deserialize(&mut self.stream)?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,13 +1,31 @@
 use thiserror::Error;
 
+use crate::packet::{MAX_CMD_SIZE, MAX_PACKET_SIZE, MAX_PAYLOAD_SIZE, MIN_PACKET_SIZE};
+
 #[derive(Error, Debug)]
 pub enum RconError {
-    #[error("invalid packet")]
-    InvalidPacket,
-    #[error("todo")]
+    #[error("bad packet from server")]
+    BadResponsePacket,
+
+    #[error("io failure")]
     IO(#[from] std::io::Error),
+
     #[error("invalid data")]
     InvalidData(#[from] std::string::FromUtf8Error),
+
+    #[error("command too long {0} (expected <= {}", MAX_CMD_SIZE)]
+    CmdTooLong(usize),
+
+    #[error("payload too long {0} (expected <= {})", MAX_PAYLOAD_SIZE)]
+    PayloadTooLong(usize),
+
+    #[error(
+        "invalid packet size {0} (expected <= {} <= {})",
+        MIN_PACKET_SIZE,
+        MAX_PACKET_SIZE
+    )]
+    InvalidPacketSize(usize),
+
     #[error("authentication failed")]
     AuthFailure,
 }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -3,9 +3,12 @@ use std::io::{Read, Write};
 
 use crate::error::RconError;
 
-const PACKET_HEADER_SIZE: i32 = 8;
-const PACKET_PADDING_SIZE: i32 = 2;
-const MIN_PACKET_SIZE: i32 = PACKET_HEADER_SIZE + PACKET_PADDING_SIZE;
+const PACKET_HEADER_SIZE: usize = 8;
+const PACKET_PADDING_SIZE: usize = 2;
+pub const MIN_PACKET_SIZE: usize = PACKET_HEADER_SIZE + PACKET_PADDING_SIZE;
+pub const MAX_PACKET_SIZE: usize = 4096; // S->C
+pub const MAX_PAYLOAD_SIZE: usize = MAX_PACKET_SIZE - MIN_PACKET_SIZE;
+pub const MAX_CMD_SIZE: usize = 1446; // C->S
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum RconReq {
@@ -78,30 +81,40 @@ impl From<MsgType> for i32 {
 
 #[derive(Debug, PartialEq)]
 pub struct Packet {
-    size: i32,
+    size: usize,
     pub id: i32,
     pub ptype: MsgType,
     pub body: String,
 }
 
 impl Packet {
-    pub fn new(id: i32, ptype: MsgType, body: String) -> Self {
-        Self {
-            size: MIN_PACKET_SIZE + body.len() as i32,
+    pub fn new(id: i32, ptype: MsgType, body: String) -> Result<Self, RconError> {
+        // Ensure body fits in an RCON packet.
+        let body_len = body.len();
+        if body_len >= MAX_PAYLOAD_SIZE {
+            return Err(RconError::PayloadTooLong(body.len()));
+        }
+
+        Ok(Self {
+            size: MIN_PACKET_SIZE + body_len,
             id,
             ptype,
             body,
-        }
+        })
     }
 
     pub fn serialize(&self, w: &mut impl Write) -> Result<(), RconError> {
-        let mut buf: Vec<u8> = Vec::with_capacity(self.size as usize);
+        // Ensure size is within spec.
+        if !(MIN_PACKET_SIZE..=MAX_PACKET_SIZE).contains(&self.size) {
+            return Err(RconError::InvalidPacketSize(self.size));
+        }
+        let size_raw = self.size as i32; // conversion ok after size check
 
-        buf.extend_from_slice(&self.size.to_le_bytes());
+        let mut buf: Vec<u8> = Vec::with_capacity(self.size);
+        buf.extend_from_slice(&size_raw.to_le_bytes());
         buf.extend_from_slice(&self.id.to_le_bytes());
 
         let ptype_raw: i32 = self.ptype.into();
-
         buf.extend_from_slice(&ptype_raw.to_le_bytes());
         buf.extend_from_slice(self.body.as_bytes());
         buf.extend_from_slice(&[0x00, 0x00]); // empty string and null terminator
@@ -113,29 +126,37 @@ impl Packet {
         // Read i32 packet fields.
         let mut field_buf = [0u8; 4]; // tmp buffer for i32 packet fields
         r.read_exact(&mut field_buf)?;
-        let size = i32::from_le_bytes(field_buf);
+        let size_raw = i32::from_le_bytes(field_buf);
         r.read_exact(&mut field_buf)?;
         let id = i32::from_le_bytes(field_buf);
         r.read_exact(&mut field_buf)?;
         let ptype_raw = i32::from_le_bytes(field_buf);
 
+        // Ensure size is valid: non-negative and within spec.
+        let Ok(size) = usize::try_from(size_raw) else {
+            return Err(RconError::BadResponsePacket);
+        };
+        if !(MIN_PACKET_SIZE..=MAX_PACKET_SIZE).contains(&size) {
+            return Err(RconError::InvalidPacketSize(size));
+        }
+
         // Read body.
         let body_len = size - MIN_PACKET_SIZE;
         let body = match body_len.cmp(&0) {
             Ordering::Greater => {
-                let mut body_buf = vec![0u8; body_len as usize];
+                let mut body_buf = vec![0u8; body_len];
                 r.read_exact(&mut body_buf)?;
                 String::from_utf8(body_buf)?
             }
             Ordering::Equal => String::new(),
-            Ordering::Less => return Err(RconError::InvalidPacket),
+            Ordering::Less => return Err(RconError::BadResponsePacket),
         };
 
         // Read terminating bytes.
         let mut term_buf = [0u8; 2];
         r.read_exact(&mut term_buf)?;
         if term_buf[0] != 0 || term_buf[1] != 0 {
-            return Err(RconError::InvalidPacket);
+            return Err(RconError::BadResponsePacket);
         }
 
         // Note: Deserialized packets will always be response messages. The tag
@@ -156,16 +177,38 @@ impl Packet {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     use std::io::Cursor;
 
-    use super::*;
+    #[test]
+    fn new_packet() {
+        let body = String::from("list");
+        let res = Packet::new(42, MsgType::Request(RconReq::ExecCommand), body.clone());
+        assert!(res.is_ok());
+
+        let p = res.unwrap();
+        assert_eq!(p.id, 42);
+        assert_eq!(p.ptype, MsgType::Request(RconReq::ExecCommand));
+        assert_eq!(p.body, body);
+        assert_eq!(p.size, MIN_PACKET_SIZE + body.len());
+    }
+
+    #[test]
+    fn new_packet_too_long_body() {
+        let body = String::from_utf8([0x61u8; MAX_PACKET_SIZE].into()).unwrap();
+        let res = Packet::new(42, MsgType::Request(RconReq::ExecCommand), body);
+        assert!(res.is_err());
+    }
 
     #[test]
     fn serialize_auth() {
+        // size = 17, id = 1, ptype = 3, body = "passwrd", \0\0
         let expected = [
             17, 0, 0, 0, 1, 0, 0, 0, 3, 0, 0, 0, 112, 97, 115, 115, 119, 114, 100, 0, 0,
         ];
-        let p = Packet::new(1, MsgType::Request(RconReq::Auth), "passwrd".into());
+        let p = Packet::new(1, MsgType::Request(RconReq::Auth), "passwrd".into())
+            .expect("password should fit in packet body");
         let mut buf = Vec::new();
         p.serialize(&mut buf).unwrap();
         print_buffer_hex(&buf);
@@ -176,7 +219,10 @@ mod tests {
     #[test]
     fn deserialize_auth_response() {
         // id == 0 in AuthResponse indicates authn success
-        let expected = Packet::new(0, MsgType::Response(RconResp::AuthResponse), "".into());
+        let expected = Packet::new(0, MsgType::Response(RconResp::AuthResponse), String::new())
+            .expect("empty string should fit in packet body");
+
+        // size = 10, id = 0, ptype = 2, body = "", \0\0
         let data = [10, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0];
 
         // Use a `Cursor` to fulfill the `Read` trait boundary on an array.
@@ -186,16 +232,68 @@ mod tests {
         expected.serialize(&mut buf).unwrap();
         print_buffer_hex(&buf);
 
-        assert_eq!(packet, expected)
+        assert_eq!(packet, expected);
+    }
+
+    #[test]
+    fn deserialize_neg_size() {
+        // A packet has a positive size.
+        // size = -1, id = 42, ptype = 0, body = "", \0\0
+        let data = [255, 255, 255, 255, 42, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let res = Packet::deserialize(&mut Cursor::new(data));
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn deserialize_too_small_size() {
+        // A packet is at least 10 bytes.
+        // size = 9, id = 42, ptype = 0, body = "", \0\0
+        let data = [9, 0, 0, 0, 42, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let res = Packet::deserialize(&mut Cursor::new(data));
+        assert!(res.is_err());
+        let Err(RconError::InvalidPacketSize(s)) = res else {
+            panic!();
+        };
+        assert_eq!(s, 9);
+    }
+
+    #[test]
+    fn deserialize_too_large_size() {
+        // A packet is at most 4096 bytes.
+        // size = 4097, id = 42, ptype = 0, body = "", \0\0
+        let data = [1, 16, 0, 0, 42, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let res = Packet::deserialize(&mut Cursor::new(data));
+        assert!(res.is_err());
+        let Err(RconError::InvalidPacketSize(s)) = res else {
+            panic!();
+        };
+        assert_eq!(s, 4097);
+    }
+
+    #[test]
+    fn serialize_bad_size() {
+        let packet = Packet {
+            size: usize::MAX,
+            id: 0,
+            ptype: MsgType::Request(RconReq::ExecCommand),
+            body: "list".to_string(),
+        };
+        let mut buf = Vec::new();
+        let res = packet.serialize(&mut buf);
+        assert!(res.is_err());
+        let Err(RconError::InvalidPacketSize(s)) = res else {
+            panic!();
+        };
+        assert_eq!(s, usize::MAX);
     }
 
     /// Print bytes as hex view for `--nocapture` or `--show-output`.
     fn print_buffer_hex(buf: &[u8]) {
         for line in buf.chunks(16) {
             for byte in line {
-                print!("{byte:02x} ")
+                print!("{byte:02x} ");
             }
-            println!()
+            println!();
         }
     }
 }


### PR DESCRIPTION
#### Description

The [RCON packet wire-representation](https://developer.valvesoftware.com/wiki/Source_RCON_Protocol#Basic_Packet_Structure) includes a (little-endian) `i32` field `size` that represents the total number of bytes transferred, including packet headers and payload. The max possible packet size is 4096 (server response); some servers also limit the max command payload to be lower than 4096 bytes (e.g. [Minecraft](https://wiki.vg/RCON#Fragmentation)) from clients.

To avoid general allocation bugs (negative sizes), payload consistency, and (most importantly) buffer overflow exploits, the `size` field must be checked to be within the spec bounds.