### PR TITLE
Implement authn according to spec

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,6 @@ pub enum Error {
     )]
     InvalidPacketSize(usize),
 
-    #[error("authentication failed")]
-    AuthFailure,
+    #[error("authentication failed: {0}")]
+    AuthFailure(String),
 }


### PR DESCRIPTION
### Description

The [RCON spec](https://developer.valvesoftware.com/wiki/Source_RCON_Protocol) says that:

> When the server receives an auth request, it will respond with an empty SERVERDATA_RESPONSE_VALUE, followed immediately by a SERVERDATA_AUTH_RESPONSE indicating whether authentication succeeded or failed. Note that the status code is returned in the packet id field, so when pairing the response with the original auth request, you may need to look at the packet id of the preceeding SERVERDATA_RESPONSE_VALUE.

Not all servers follow this convention, but will only send an `SERVERDATA_AUTH_RESPONSE`. This could be considered unsafe, but there's nothing the client can do about the server implementation. Instead, allow bare `SERVERDATA_AUTH_RESPONSE`, but add indicators of the handshake result (which can be logged in warnings).